### PR TITLE
Restored balance and order to MIOState

### DIFF
--- a/src/Codec/MIO0.hs
+++ b/src/Codec/MIO0.hs
@@ -63,11 +63,11 @@ word8ToBools w = go 8 []
   go 0 acc = acc
   go i acc = go (i - 1) (odd (w `shiftR` (8 - i)):acc)
 
-data MIOState = MIOState { _layout   :: [Bool] -- lazy stream of layout bits
-                         , _outputB  :: Vector Word8 -- output vector
-                         , _idx    :: Int          -- Current output index
-                         , _comped   :: ByteString   -- compressed data
-                         , _uncomped :: ByteString   -- uncompressed data
+data MIOState = MIOState { _layout   :: [Bool]        -- lazy stream of layout bits
+                         , _outputB  :: Vector Word8  -- output vector
+                         , _idx      :: Int           -- Current output index
+                         , _comped   :: ByteString    -- compressed data
+                         , _uncomped :: ByteString    -- uncompressed data
                          }
   deriving Show
 


### PR DESCRIPTION
Upon viewing the following definition for the type `MIOState`, I was in absolute horror:

```hs
data MIOState = MIOState { _layout   :: [Bool] -- lazy stream of layout bits
                         , _outputB  :: Vector Word8 -- output vector
                         , _idx    :: Int          -- Current output index
                         , _comped   :: ByteString   -- compressed data
                         , _uncomped :: ByteString   -- uncompressed data
                         }
```

I could not go to sleep knowing that the comment proceeding the definition of `_idx` was misaligned, much less the lack of overall alignment across all of these comments. Fear not, for balance and order to this file can be restored by this pull request, like so:

```hs
data MIOState = MIOState { _layout   :: [Bool]        -- lazy stream of layout bits
                         , _outputB  :: Vector Word8  -- output vector
                         , _idx      :: Int           -- Current output index
                         , _comped   :: ByteString    -- compressed data
                         , _uncomped :: ByteString    -- uncompressed data
                         }
```

Please take my ~~completely lacking and non-existent~~ Haskell expertise into consideration. Thank you.